### PR TITLE
Upgrade wagtail 6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ EXPOSE 8080
 # 2. Set PORT variable that is used by Gunicorn. This should match "EXPOSE"
 #    command.
 ENV PYTHONUNBUFFERED=1 \
-  PORT=8080
+    PORT=8080 \
+    DJANGO_SETTINGS_MODULE=alloydflanagan.settings.production
 
 # Use /app folder as a directory where the source code is stored.
 WORKDIR /app
@@ -33,8 +34,8 @@ WORKDIR /app
 COPY app /app/
 
 #TODO: get uv to use system python instead of downloading -- faster, more reliable.
-RUN pip install --no-cache-dir uv==0.7.13 && \
-    uv sync --frozen
+RUN pip install --no-cache-dir uv==0.7.17 && \
+    uv sync --frozen --no-dev
 
 # Note: Fly automatically sets DATABASE_URL
 CMD ["make", "run-server"]

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,5 +1,3 @@
-# files collected by manage.py collectstatic
-
 # yarn pnp files
 .pnp.*
 .yarn/*
@@ -13,6 +11,7 @@
 .env*
 sqlite3.db
 
+# files collected by manage.py collectstatic
 media/*
 !media/.keep
 static/*

--- a/app/alloydflanagan/home/models.py
+++ b/app/alloydflanagan/home/models.py
@@ -17,7 +17,7 @@ class HomePage(Page):
         ('text', RichTextBlock()),  #probably will use custom type later
         ('image', ImageChooserBlock()),
         ('header', HeaderBlock()),
-    ], use_json_field=True, blank=True)
+    ], blank=True)
 
     content_panels = Page.content_panels + [
         FieldPanel("intro", classname="full"),

--- a/app/alloydflanagan/search/views.py
+++ b/app/alloydflanagan/search/views.py
@@ -2,7 +2,7 @@ from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.template.response import TemplateResponse
 
 from wagtail.models import Page
-from wagtail.search.models import Query
+from wagtail.contrib.search_promotions.models import Query
 
 
 def search(request):

--- a/app/alloydflanagan/settings/base.py
+++ b/app/alloydflanagan/settings/base.py
@@ -29,6 +29,7 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
+    "wagtail.contrib.search_promotions",
     "django.contrib.staticfiles",
     "wagtail.contrib.forms",
     "wagtail.contrib.redirects",

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "gunicorn>=23.0.0",
     "psycopg>=3.2.7",
     "structlog>=25.3.0",
-    "wagtail<5.3",
+    "wagtail<6.1.0",
 ]
 
 [dependency-groups]

--- a/app/uv.lock
+++ b/app/uv.lock
@@ -56,7 +56,7 @@ requires-dist = [
     { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "psycopg", specifier = ">=3.2.7" },
     { name = "structlog", specifier = ">=25.3.0" },
-    { name = "wagtail", specifier = "<5.3" },
+    { name = "wagtail", specifier = "<6.1.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -671,6 +671,18 @@ wheels = [
 ]
 
 [[package]]
+name = "laces"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/9a/9192d6a74e2c6db4f705dd98f56be488e47373172c13f4916aeabc4d68b8/laces-0.1.2.tar.gz", hash = "sha256:3218e09c1889ae5cf3fc7a82f5bb63ec0c7879889b6a9760bfc42323c694b84d", size = 29264, upload-time = "2025-01-14T04:37:34.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/fe/31f76f5cb2579bdda208aa257ce5482653f22ab1bad3e128fe2f803fa2f1/laces-0.1.2-py3-none-any.whl", hash = "sha256:980cdaf9a31e883a2b8198132e2388931a4eb8814f5bfa5d8bba13ff9f657b7c", size = 22462, upload-time = "2025-01-14T04:37:30.636Z" },
+]
+
+[[package]]
 name = "lazy-object-proxy"
 version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1273,7 +1285,7 @@ wheels = [
 
 [[package]]
 name = "wagtail"
-version = "5.2"
+version = "6.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyascii" },
@@ -1288,15 +1300,16 @@ dependencies = [
     { name = "draftjs-exporter" },
     { name = "html5lib" },
     { name = "l18n" },
+    { name = "laces" },
     { name = "openpyxl" },
     { name = "pillow" },
     { name = "requests" },
     { name = "telepath" },
     { name = "willow", extra = ["heif"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/10/8570ddb519455c8a07ac4dd9c95b46aecc5ca2c776a8d0ed143bdf230ea9/wagtail-5.2.tar.gz", hash = "sha256:695b2af9c42ab7b293f489abc9e3dcaa2cbe28977fe0b730683c43b46e0f75d1", size = 6348635, upload-time = "2023-11-01T12:56:04.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/cf/d97ca7e7bf82e1dede67229d5173bc50969800ab21c2ce2aad44e4a84753/wagtail-6.0.6.tar.gz", hash = "sha256:c00a05eb4cee1e4bbfe7550e30ec121ecdb5143e328d75aaa586b93dff5d1b95", size = 6269592, upload-time = "2024-07-11T10:48:15.825Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/73/b5979b6f325d6d0ccc2842a08c6069fd6fa1a210487be237b98a0761e237/wagtail-5.2-py3-none-any.whl", hash = "sha256:a1d78f99d33ade5ac3ce7dca92f570f28513214d4e203421813ba544cd38eac2", size = 8960488, upload-time = "2023-11-01T12:55:57.842Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/6d/ab208f775de97a926fd0bb2ce332c27e54799cb137404e495fc563c360c3/wagtail-6.0.6-py3-none-any.whl", hash = "sha256:9765fd986b39985cfc8227d0973ada6574c78341d52883b096ee2d89662fad36", size = 8720449, upload-time = "2024-07-11T10:48:11.006Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
1.Bump wagtail to version 6.
2. Minor code changes per the migration guide.