### PR TITLE
Fix gunicorn binding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,16 @@ rootshell:
 dbshell:
 	docker compose exec -it postgres /bin/bash -i
 
+exec_on_db:
+	# TODO: get machine ID from app name
+	fly machine exec 1857276f657438 --app alf-wag-db 'bash -c "psql --version"'
+
+fly_dbshell:
+	fly machine exec 6830393f152ed8 '/bin/bash -c "cd app && uv run python manage.py dbshell"'
+
+fly_console:
+	fly console --machine 6830393f152ed8
+
 # this makes up for the fact that make has no command to show what tasks are defined
 # no attempt was made at a universal solution; you'll need to enhance for any but most basic case
 targets:

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ fly_dbshell:
 fly_console:
 	fly console --machine 6830393f152ed8
 
+fly_users:
+	# TODO: should be able to make general bash script to accept arbitrary python.
+	fly machine exec 48e42d9c724718 '/bin/bash -c "cd app && uv run python manage.py shell -c \"from django.contrib.auth.models import User; print(User.objects.count())\""'
+
 # this makes up for the fact that make has no command to show what tasks are defined
 # no attempt was made at a universal solution; you'll need to enhance for any but most basic case
 targets:

--- a/app/Makefile
+++ b/app/Makefile
@@ -4,7 +4,7 @@ run-server:
 	echo "Starting server..."
 	$(PYTHON) manage.py migrate
 	$(PYTHON) manage.py collectstatic --noinput
-	uv run gunicorn --timeout 30 alloydflanagan.wsgi:application --log-file -
+	uv run gunicorn --timeout 30 alloydflanagan.wsgi:application --bind 0.0.0.0:8080 --log-file -
 	echo "Server is up."
 
 djhtml:

--- a/app/alloydflanagan/settings/base.py
+++ b/app/alloydflanagan/settings/base.py
@@ -154,5 +154,5 @@ BASE_URL = "https://alloydflanagan.com"
 CSRF_TRUSTED_ORIGINS = [
     "https://alloydflanagan.com",
     "https://www.alloydflanagan.com",
-    "https://alloydflanagan-wag.fly.dev/",
+    "https://alloydflanagan-wag.fly.dev",
 ]

--- a/fly.toml
+++ b/fly.toml
@@ -11,7 +11,7 @@ primary_region = 'iad'
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = true
+  auto_stop_machines = 'suspend'
   auto_start_machines = true
   min_machines_running = 1
   processes = ['app']

--- a/fly.toml
+++ b/fly.toml
@@ -11,7 +11,7 @@ primary_region = 'iad'
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = 'suspend'
+  auto_stop_machines = true
   auto_start_machines = true
   min_machines_running = 1
   processes = ['app']


### PR DESCRIPTION
1. Fixes CSRF error by removing a trailing / from settings.
2. Ensures gunicorn binds required addr:port.
3. Adds half-baked fly complex commands to Makefile.